### PR TITLE
Remove period filter buttons from PerformanceDashboard; update tests,…

### DIFF
--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -481,7 +481,21 @@
   "PLACEHOLDER_SELLER": "Search Seller",
   "BUTTON_FILTER": "Filter",
   "BUTTON_CLEAR": "Clear",
-  "PERFORMANCE_TABLE_TITLE": "Performance Report Table"
+  "PERFORMANCE_TABLE_TITLE": "Performance Report Table", 
 
+  "CARD_CLIENTS": "Clients",
+  "CARD_TOTAL_SALES": "Total Sales",
+  "CARD_MONTH_SALES": "Monthly Sales",
+  "CARD_QUARTER_SALES": "Quarterly Sales", 
+  "SHOWING_RESULTS_FOR": "Showing results for",
+  "NO_RESULTS": "No matching results found.", 
+  "PERFORMANCE_TITLE_DETAIL": "Sales KPIs",
+  "PERFORMANCE_SUBTITLE_DETAIL": "Detailed performance metrics for the selected seller.", 
+  "SHOWING_RESULTS_GLOBAL": "Showing consolidated results for all sellers",
+  "ADMIN_NAME": "Administrator", 
+  "PERFORMANCE_STATUS_GOOD": "High performance",
+  "PERFORMANCE_STATUS_AVERAGE": "Average performance",
+  "PERFORMANCE_STATUS_LOW": "Low performance"
 
 }
+  

--- a/public/assets/i18n/es.json
+++ b/public/assets/i18n/es.json
@@ -481,6 +481,23 @@
   "PLACEHOLDER_SELLER": "Buscar Vendedor",
   "BUTTON_FILTER": "Filtrar",
   "BUTTON_CLEAR": "Limpiar",
-  "PERFORMANCE_TABLE_TITLE": "Tabla de Reportes de Desempeño"
+  "PERFORMANCE_TABLE_TITLE": "Tabla de Reportes de Desempeño",
+  
+  "CARD_CLIENTS": "Clientes",
+  "CARD_TOTAL_SALES": "Ventas Totales",
+  "CARD_MONTH_SALES": "Ventas Mensuales",
+  "CARD_QUARTER_SALES": "Ventas Trimestrales",
+
+  "SHOWING_RESULTS_FOR": "Mostrando resultados para",
+  "NO_RESULTS": "No se encontraron resultados coincidentes.",
+
+  "PERFORMANCE_TITLE_DETAIL": "Indicadores de Desempeño",
+  "PERFORMANCE_SUBTITLE_DETAIL": "Análisis detallado del desempeño del vendedor seleccionado.", 
+  "SHOWING_RESULTS_GLOBAL": "Mostrando resultados consolidados para todos los vendedores", 
+  "ADMIN_NAME": "Administrador", 
+
+  "PERFORMANCE_STATUS_GOOD": "Desempeño alto",
+  "PERFORMANCE_STATUS_AVERAGE": "Desempeño medio",
+  "PERFORMANCE_STATUS_LOW": "Desempeño bajo"
 
 }

--- a/src/app/performance/performance-dashboard/performance-dashboard.component.html
+++ b/src/app/performance/performance-dashboard/performance-dashboard.component.html
@@ -1,140 +1,165 @@
-<div class="container my-5">
+<div class="container py-5">
 
-  <h2 class="mb-2">{{ 'PERFORMANCE_TITLE' | translate }}</h2>
-  <p  class="mb-4">{{ 'PERFORMANCE_SUBTITLE' | translate }}</p>
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-10">
+      <h2 class="mb-2">
+        {{ selectedSeller
+          ? (selectedSeller.name + ' – ' + ('PERFORMANCE_TITLE_DETAIL' | translate))
+          : (adminName() + ' – ' + ('PERFORMANCE_TITLE' | translate)) }}
+      </h2>
+      <p class="mb-1 text-muted">
+        {{ selectedSeller ? ('PERFORMANCE_SUBTITLE_DETAIL' | translate) : ('PERFORMANCE_SUBTITLE' | translate) }}
+      </p>
+      <p *ngIf="!selectedSeller" class="text-muted small fst-italic">
+        {{ 'SHOWING_RESULTS_GLOBAL' | translate }}
+      </p>
+    </div>
+  </div>
 
-  <form [formGroup]="filterForm" class="row align-items-end g-3 mb-4">
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-10">
+      <form [formGroup]="filterForm" class="mb-3">
+        <label for="sellerSearch" class="form-label fw-semibold">
+          {{ 'FILTER_SELLER' | translate }}
+        </label>
 
-    <div class="col-md-4">
-      <label class="form-label">{{ 'FILTER_SELLER' | translate }}</label>
+        <div *ngIf="sellersErr()" class="alert alert-danger py-2 px-3 small mb-2">
+          {{ 'PERFORMANCE_SELLERS_ERROR' | translate }}
+        </div>
 
-      <div *ngIf="sellersErr()" class="alert alert-danger p-2">
-        {{ 'PERFORMANCE_SELLERS_ERROR' | translate }}
-      </div>
+        <div *ngIf="sellersLoading()" class="d-flex align-items-center mb-2">
+          <div class="spinner-border spinner-border-sm me-2"></div>
+          <small>{{ 'LOADING_BUTTON_TEXT' | translate }}</small>
+        </div>
 
-      <div *ngIf="sellersLoading()" class="d-flex align-items-center">
-        <div class="spinner-border spinner-border-sm me-2"></div>
-        <small>{{ 'LOADING_BUTTON_TEXT' | translate }}</small>
-      </div>
+        <div class="position-relative seller-dropdown">
+          <input id="sellerSearch"
+                 type="text"
+                 class="form-control"
+                 placeholder="{{ 'PLACEHOLDER_SELLER' | translate }}"
+                 autocomplete="off"
+                 [formControl]="sellerNameControl"
+                 (focus)="dropdownOpen = true"
+                 (input)="onSellerInputChange($event)"
+                 (keydown.escape)="dropdownOpen = false"
+                 aria-autocomplete="list"
+                 aria-controls="seller-options">
 
-      <div class="position-relative">
-        <input type="text"
-               class="form-control"
-               placeholder="{{ 'PLACEHOLDER_SELLER' | translate }}"
-               autocomplete="off"
-               [formControl]="sellerNameControl"
-               (focus)="dropdownOpen = true"
-               (input)="onSellerInputChange($event)"
-               (keydown.escape)="dropdownOpen = false">
+          <ul *ngIf="dropdownOpen"
+              id="seller-options"
+              class="list-group position-absolute w-100 shadow-sm z-3 overflow-auto"
+              [style.maxHeight.px]="220">
+            <li *ngFor="let s of filteredSellers$ | async"
+                class="list-group-item list-group-item-action"
+                (mousedown)="selectSeller(s)">
+              {{ s.name }}
+            </li>
+            <li *ngIf="(filteredSellers$ | async)?.length === 0"
+                class="list-group-item disabled text-center text-muted">
+              {{ 'NO_RESULTS' | translate }}
+            </li>
+          </ul>
+        </div>
+      </form>
 
-        <ul *ngIf="dropdownOpen"
-            class="list-group position-absolute w-100 shadow-sm z-3"
-            [style.max-height.px]="220"
-            [style.overflow-y]="'auto'">
-          <li *ngFor="let s of filteredSellers$ | async"
-              class="list-group-item list-group-item-action"
-              (mousedown)="selectSeller(s)">
-            {{ s.name }}
-          </li>
-          <li *ngIf="(filteredSellers$ | async)?.length === 0"
-              class="list-group-item disabled">
-            {{ 'NO_RESULTS' | translate }}
-          </li>
-        </ul>
+      <div *ngIf="selectedSeller" class="mb-4">
+        <strong class="text-muted small">
+          {{ 'SHOWING_RESULTS_FOR' | translate }}: {{ selectedSeller.name }}
+        </strong>
       </div>
     </div>
+  </div>
 
-    <div class="col-md-3">
-      <label class="form-label" for="period-select">
-        {{ 'FILTER_PERIOD' | translate }}
-      </label>
-      <select id="period-select" class="form-select" formControlName="period">
-        <option value="month">{{ 'FILTER_MONTH'    | translate }}</option>
-        <option value="quarter">{{ 'FILTER_QUARTER' | translate }}</option>
-        <option value="all">{{ 'FILTER_ALL' | translate }}</option>
-      </select>
-    </div>
-
-    <div class="col-md-5 d-flex gap-2">
-      <button type="button"
-              class="btn btn-primary flex-grow-1"
-              (click)="refresh()"
-              [disabled]="loading()">
-        <ng-container *ngIf="!loading(); else loadingTpl">
-          <i class="bi bi-funnel me-1"></i> {{ 'BUTTON_FILTER' | translate }}
-        </ng-container>
-        <ng-template #loadingTpl>
-          <span class="spinner-border spinner-border-sm me-1"></span>
-          {{ 'LOADING_BUTTON_TEXT' | translate }}
-        </ng-template>
-      </button>
-
-      <button type="button"
-              class="btn btn-outline-secondary"
-              (click)="clearFilters()">
-        {{ 'BUTTON_CLEAR' | translate }}
-      </button>
-    </div>
-  </form>
-
-  <div *ngIf="summaryKpi()" class="row g-3 mb-4">
-    <div class="col-6 col-lg-3" *ngFor="let c of cards">
-      <div class="card shadow-sm h-100 text-center">
-        <div class="card-body">
-          <h6 class="card-title">{{ c.title | translate }}</h6>
-          <h3 class="mb-0">{{ c.value }}</h3>
+  <div *ngIf="summaryKpi()" class="row g-3 mb-4 justify-content-center">
+    <div class="col-6 col-md-3 col-lg-2" *ngFor="let c of cards">
+      <div class="card shadow-sm h-100 text-center border-0 rounded-3">
+        <div class="card-body py-3">
+          <h6 class="card-title text-muted small">{{ c.title | translate }}</h6>
+          <h3 class="mb-0 fw-bold d-flex justify-content-center align-items-baseline gap-1 flex-wrap">
+            <ng-container *ngIf="c.value?.amount; else plainValue">
+              <span>{{ c.value.amount }}</span>
+              <span class="small text-muted">{{ c.value.currency }}</span>
+            </ng-container>
+            <ng-template #plainValue>{{ c.value }}</ng-template>
+          </h3>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="position-relative">
-    <div *ngIf="isLoading" class="overlay-spinner">
-      <div class="spinner-border"></div>
-    </div>
+  <div class="row justify-content-center">
+    <div class="col-12 col-lg-10">
+      <div class="position-relative">
 
-    <div class="table-responsive scroll-table">
-      <table class="table table-hover table-bordered">
-        <thead class="table-light sticky-head text-center">
-          <tr>
-            <th>{{ 'TABLE_SELLER'    | translate }}</th>
-            <th>{{ 'TABLE_CLIENTS'   | translate }}</th>
-            <th>{{ 'TABLE_TOTAL'     | translate }}</th>
-            <th>{{ 'TABLE_MONTHLY'   | translate }}</th>
-            <th>{{ 'TABLE_QUARTERLY' | translate }}</th>
-          </tr>
-        </thead>
+        <div *ngIf="isLoading" class="position-absolute top-50 start-50 translate-middle z-3">
+          <div class="spinner-border text-primary" role="status" aria-label="Loading..."></div>
+        </div>
 
-        <tbody>
-          <ng-container *ngIf="isLoading">
-            <tr *ngFor="let _ of skeletonRows">
-              <td colspan="5">
-                <div class="placeholder-glow">
-                  <span class="placeholder col-12"></span>
-                </div>
-              </td>
-            </tr>
-          </ng-container>
+        <div class="table-responsive">
+          <table class="table table-bordered table-hover align-middle text-center shadow-sm mb-0">
+            <thead class="table-light sticky-top">
+              <tr>
+                <th scope="col">{{ 'TABLE_SELLER' | translate }}</th>
+                <th scope="col">{{ 'TABLE_CLIENTS' | translate }}</th>
+                <th scope="col">{{ 'TABLE_TOTAL' | translate }}</th>
+                <th scope="col">{{ 'TABLE_MONTHLY' | translate }}</th>
+                <th scope="col">{{ 'TABLE_QUARTERLY' | translate }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <ng-container *ngIf="isLoading">
+                <tr *ngFor="let _ of skeletonRows">
+                  <td colspan="5">
+                    <div class="placeholder-glow">
+                      <span class="placeholder col-12"></span>
+                    </div>
+                  </td>
+                </tr>
+              </ng-container>
 
-          <ng-container *ngIf="!isLoading">
-            <tr *ngFor="let k of kpis(); trackBy: trackById" class="text-center">
-              <td>{{ k.sellerName }}</td>
-              <td>{{ k.clientCount }}</td>
-              <td>{{ k.totalSales     | currency:k.currency:'symbol':'1.0-0' }}</td>
-              <td>{{ k.monthlySales   | currency:k.currency:'symbol':'1.0-0' }}</td>
-              <td>{{ k.quarterlySales | currency:k.currency:'symbol':'1.0-0' }}</td>
-            </tr>
-          </ng-container>
-        </tbody>
-      </table>
+              <ng-container *ngIf="!isLoading">
+                <tr *ngFor="let k of kpis(); trackBy: trackById">
+                  <td>{{ k.sellerName }}</td>
+                  <td>{{ k.clientCount }}</td>
+                  <td>
+                    {{ asFormattedMoney(k.totalSales, k.currency).amount }}
+                    {{ asFormattedMoney(k.totalSales, k.currency).currency }}
+                    <i [ngClass]="getPerformanceIcon(k.totalSales)"
+                       class="ms-2"
+                       [attr.aria-label]="getPerformanceLabel(k.totalSales) | translate"
+                       [attr.title]="getPerformanceLabel(k.totalSales) | translate"></i>
+                  </td>
+                  <td>
+                    {{ asFormattedMoney(k.monthlySales, k.currency).amount }}
+                    {{ asFormattedMoney(k.monthlySales, k.currency).currency }}
+                    <i [ngClass]="getPerformanceIcon(k.monthlySales)"
+                       class="ms-2"
+                       [attr.aria-label]="getPerformanceLabel(k.monthlySales) | translate"
+                       [attr.title]="getPerformanceLabel(k.monthlySales) | translate"></i>
+                  </td>
+                  <td>
+                    {{ asFormattedMoney(k.quarterlySales, k.currency).amount }}
+                    {{ asFormattedMoney(k.quarterlySales, k.currency).currency }}
+                    <i [ngClass]="getPerformanceIcon(k.quarterlySales)"
+                       class="ms-2"
+                       [attr.aria-label]="getPerformanceLabel(k.quarterlySales) | translate"
+                       [attr.title]="getPerformanceLabel(k.quarterlySales) | translate"></i>
+                  </td>
+                </tr>
+              </ng-container>
+            </tbody>
+          </table>
 
-      <div *ngIf="!isLoading && kpis().length === 0" class="alert alert-info">
-        {{ 'PERFORMANCE_NO_DATA' | translate }}
+          <div *ngIf="!isLoading && kpis().length === 0" class="alert alert-info text-center mt-3">
+            {{ 'PERFORMANCE_NO_DATA' | translate }}
+          </div>
+        </div>
+
+        <div *ngIf="loadErr()" class="alert alert-danger mt-4 text-center">
+          {{ 'PERFORMANCE_LOAD_ERROR' | translate }}
+        </div>
       </div>
     </div>
   </div>
 
-  <div *ngIf="loadErr()" class="alert alert-danger mt-3">
-    {{ 'PERFORMANCE_LOAD_ERROR' | translate }}
-  </div>
 </div>

--- a/src/app/performance/performance-dashboard/performance-dashboard.component.spec.ts
+++ b/src/app/performance/performance-dashboard/performance-dashboard.component.spec.ts
@@ -1,138 +1,116 @@
-/* ===========================================================================
- * performance-dashboard.component.spec.ts
- * ===========================================================================
- * Test suite – PerformanceDashboardComponent
- * --------------------------------------------------------------------------*/
-
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { ReactiveFormsModule }   from '@angular/forms';
-import { TranslateModule }       from '@ngx-translate/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
 import { of, throwError, firstValueFrom } from 'rxjs';
-import { faker }                 from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { PerformanceDashboardComponent } from './performance-dashboard.component';
-import { PerformanceReportService }      from '../performance-report.service';
-import { SellerService }                 from '../../seller/seller.service';
-import { PerformanceKpi }                from '../../models/performance-report.model';
-import { Seller }                        from '../../seller/seller.model';
+import { PerformanceReportService } from '../performance-report.service';
+import { SellerService } from '../../seller/seller.service';
+import { Seller } from '../../seller/seller.model';
+import { PerformanceKpi } from '../../models/performance-report.model';
 
 function buildSeller(): Seller {
   return {
-    id        : faker.string.uuid(),
-    name      : faker.person.fullName(),
-    email     : faker.internet.email(),
-    phone     : faker.phone.number(),
-    address   : faker.location.streetAddress(),
-    zone      : faker.location.city(),
-    specialty : faker.word.adjective(),
-    password  : faker.internet.password()
+    id: faker.string.uuid(),
+    name: faker.person.fullName(),
+    email: faker.internet.email(),
+    phone: faker.phone.number(),
+    address: faker.location.streetAddress(),
+    zone: faker.location.city(),
+    specialty: faker.word.adjective(),
+    password: faker.internet.password()
   } as Seller;
 }
 
 function buildKpi(seller: Seller): PerformanceKpi {
   return {
-    sellerId       : seller.id,
-    sellerName     : seller.name,
-    clientCount    : faker.number.int({ min: 5, max: 40 }),
-    totalSales     : faker.number.int({ min: 1_000, max: 10_000 }),
-    monthlySales   : faker.number.int({ min: 100, max: 3_000 }),
-    quarterlySales : faker.number.int({ min: 400, max: 9_000 }),
-    currency       : 'USD'
+    sellerId: seller.id,
+    sellerName: seller.name,
+    clientCount: faker.number.int({ min: 5, max: 40 }),
+    totalSales: faker.number.int({ min: 1000, max: 10000 }),
+    monthlySales: faker.number.int({ min: 100, max: 3000 }),
+    quarterlySales: faker.number.int({ min: 400, max: 9000 }),
+    currency: 'USD'
   };
 }
 
-const kpiSvcSpy    = jasmine.createSpyObj<PerformanceReportService>(
-  'PerformanceReportService',
-  ['getAll', 'getBySeller', 'getSummary']
-);
+const kpiSvcSpy = jasmine.createSpyObj<PerformanceReportService>('PerformanceReportService', [
+  'getAll',
+  'getBySeller'
+]);
 
-const sellerSvcSpy = jasmine.createSpyObj<SellerService>(
-  'SellerService',
-  ['getAll']
-);
+const sellerSvcSpy = jasmine.createSpyObj<SellerService>('SellerService', ['getAll']);
 
 let component: PerformanceDashboardComponent;
-let fixture  : ComponentFixture<PerformanceDashboardComponent>;
+let fixture: ComponentFixture<PerformanceDashboardComponent>;
 
-const sellers : Seller[]          = Array.from({ length: 3 }, buildSeller);
-const kpis    : PerformanceKpi[]  = sellers.map(buildKpi);
-const summary : PerformanceKpi    = {
-  sellerId       : '—',
-  sellerName     : '—',
-  clientCount    : kpis.reduce((a, k) => a + k.clientCount,    0),
-  totalSales     : kpis.reduce((a, k) => a + k.totalSales,     0),
-  monthlySales   : kpis.reduce((a, k) => a + k.monthlySales,   0),
-  quarterlySales : kpis.reduce((a, k) => a + k.quarterlySales, 0),
-  currency       : 'USD'
+const sellers: Seller[] = Array.from({ length: 3 }, buildSeller);
+const kpis: PerformanceKpi[] = sellers.map(buildKpi);
+const summary: PerformanceKpi = {
+  sellerId: 'SUMMARY',
+  sellerName: 'Resumen',
+  clientCount: kpis.reduce((a, k) => a + k.clientCount, 0),
+  totalSales: kpis.reduce((a, k) => a + k.totalSales, 0),
+  monthlySales: kpis.reduce((a, k) => a + k.monthlySales, 0),
+  quarterlySales: kpis.reduce((a, k) => a + k.quarterlySales, 0),
+  currency: 'USD'
 };
 
 describe('PerformanceDashboardComponent', () => {
-
   beforeEach(async () => {
     sellerSvcSpy.getAll.and.returnValue(of(sellers));
     kpiSvcSpy.getAll.and.returnValue(of(kpis));
-    kpiSvcSpy.getSummary.and.returnValue(of(summary));
-    kpiSvcSpy.getBySeller.and.callFake((id: string) =>
-      of(kpis.find(k => k.sellerId === id)!)
-    );
+    kpiSvcSpy.getBySeller.and.callFake((id: string) => of(kpis.find(k => k.sellerId === id)!));
 
     await TestBed.configureTestingModule({
       imports: [
+        HttpClientTestingModule,
         ReactiveFormsModule,
         TranslateModule.forRoot(),
-        PerformanceDashboardComponent         
+        PerformanceDashboardComponent
       ],
       providers: [
         { provide: PerformanceReportService, useValue: kpiSvcSpy },
-        { provide: SellerService,            useValue: sellerSvcSpy }
+        { provide: SellerService, useValue: sellerSvcSpy }
       ]
     }).compileComponents();
 
-    fixture   = TestBed.createComponent(PerformanceDashboardComponent);
+    fixture = TestBed.createComponent(PerformanceDashboardComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();                    
+    fixture.detectChanges();
   });
+
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
+
   it('fetches sellers on init', () => {
-    expect(sellerSvcSpy.getAll).toHaveBeenCalled();     
+    expect(sellerSvcSpy.getAll).toHaveBeenCalled();
     expect(component.sellers().length).toBe(3);
     expect(component.sellersErr()).toBeFalse();
   });
 
   it('loads global KPIs on init', () => {
-    expect(kpiSvcSpy.getAll).toHaveBeenCalled();        
+    expect(kpiSvcSpy.getAll).toHaveBeenCalled();
     expect(component.kpis().length).toBe(3);
     expect(component.summaryKpi()).toEqual(summary);
   });
 
-  it('filters seller names reactively', fakeAsync(async () => {
-    const partial = sellers[0].name.slice(0, 2);
-    component.sellerNameControl.setValue(partial);
-    tick(250);                                          
-    const list = await firstValueFrom(component.filteredSellers$);
-    expect(list.some(s => s.id === sellers[0].id)).toBeTrue();
-  }));
-
   it('calls getBySeller when a seller is selected', fakeAsync(() => {
     const target = sellers[1];
     component.selectSeller(target);
-    tick(250);                                        
-    expect(kpiSvcSpy.getBySeller)
-      .toHaveBeenCalledWith(target.id, jasmine.any(String), jasmine.any(String));
+    tick(250);
+    expect(kpiSvcSpy.getBySeller).toHaveBeenCalledWith(
+      target.id,
+      jasmine.any(String),
+      jasmine.any(String)
+    );
     expect(component.kpis()[0].sellerId).toBe(target.id);
   }));
-
-  it('clears filters with clearFilters()', () => {
-    component.filterForm.patchValue({ sellerId: sellers[0].id, period: 'quarter' });
-    component.clearFilters();
-    expect(component.filterForm.value).toEqual({ sellerId: '', period: 'month' });
-    expect(component.sellerNameControl.value).toBe('');
-    expect(component.dropdownOpen).toBeFalse();
-  });
 
   it('sets error flags when services fail', fakeAsync(() => {
     sellerSvcSpy.getAll.and.returnValue(throwError(() => new Error('fail')));
@@ -146,244 +124,288 @@ describe('PerformanceDashboardComponent', () => {
     expect(component.loadErr()).toBeTrue();
   }));
 
-  describe('UI-behaviour helpers', () => {
+  it('filters seller names reactively', fakeAsync(async () => {
+    const partial = sellers[0].name.slice(0, 2);
+    component.sellerNameControl.setValue(partial);
+    tick(250);
+    const list = await firstValueFrom(component.filteredSellers$);
+    expect(list.some(s => s.id === sellers[0].id)).toBeTrue();
+  }));
 
-    it('onSellerInputChange() fills sellerId and opens dropdown', () => {
-      const ev = { target: { value: sellers[0].name } } as unknown as Event;
-      component.onSellerInputChange(ev);
-      expect(component.filterForm.value.sellerId).toBe(sellers[0].id);
-      expect(component.dropdownOpen).toBeTrue();
-    });
 
-    it('onSellerInputChange() clears sellerId if name not found', () => {
-      const ev = { target: { value: 'no match' } } as unknown as Event;
-      component.onSellerInputChange(ev);
-      expect(component.filterForm.value.sellerId).toBe('');
-      expect(component.dropdownOpen).toBeTrue();
-    });
-
-    it('closeOnClickOutside() keeps dropdown open if click is inside', () => {
-      const inside = document.createElement('div');
-      inside.classList.add('seller-dropdown');
-      component.dropdownOpen = true;
-
-      component.closeOnClickOutside({ target: inside } as unknown as MouseEvent);
-      expect(component.dropdownOpen).toBeTrue();
-    });
-
-    it('closeOnClickOutside() closes dropdown if click is outside', () => {
-      const outside = document.createElement('div');
-      component.dropdownOpen = true;
-
-      component.closeOnClickOutside({ target: outside } as unknown as MouseEvent);
-      expect(component.dropdownOpen).toBeFalse();
-    });
-
-    it('closeOnEsc() always closes dropdown', () => {
-      component.dropdownOpen = true;
-      component.closeOnEsc();
-      expect(component.dropdownOpen).toBeFalse();
-    });
+  it('onSellerInputChange fills sellerId and opens dropdown', () => {
+    const ev = { target: { value: sellers[0].name } } as unknown as Event;
+    component.onSellerInputChange(ev);
+    expect(component.filterForm.value.sellerId).toBe(sellers[0].id);
+    expect(component.dropdownOpen).toBeTrue();
   });
 
-  describe('utility methods', () => {
-    let util: any;            
-    beforeEach(() => { util = component as any; });
-
-    describe('#calcRange', () => {
-      function mockNow(dateIso: string) {
-        jasmine.clock().install();
-        jasmine.clock().mockDate(new Date(dateIso));
-      }
-
-      afterEach(() => jasmine.clock().uninstall());
-
-      it('returns first day of this month → now for "month"', () => {
-        mockNow('2025-05-04T10:00:00Z');
-        const [start, end] = util.calcRange('month');
-        expect(new Date(start).getUTCDate()).toBe(1);
-        expect(new Date(end).getUTCDate()).toBe(4);
-      });
-
-      it('returns first day two months back for "quarter"', () => {
-        mockNow('2025-05-15T08:00:00Z');
-        const [start] = util.calcRange('quarter');
-        expect(new Date(start).getUTCMonth()).toBe(2);
-      });
-
-      it('returns empty strings for any other value', () => {
-        mockNow('2025-05-01T00:00:00Z');
-        expect(util.calcRange('all')).toEqual(['', '']);
-      });
-    });
-
-    it('filterSellerNames() matches sellers case-insensitively', () => {
-      const fragment = sellers[0].name.slice(1, 4).toUpperCase();
-      const res = util.filterSellerNames(fragment);
-      expect(res.some((s: Seller) => s.id === sellers[0].id)).toBeTrue();
-    });
-
-    it('isSelectedSeller() detects selected seller', () => {
-      component.filterForm.patchValue({ sellerId: sellers[2].id });
-      expect(component.isSelectedSeller(sellers[2])).toBeTrue();
-      expect(component.isSelectedSeller(sellers[0])).toBeFalse();
-    });
-
-    it('emptyRow() returns zeroed KPI row with seller data if provided', () => {
-      const kpi = util.emptyRow(sellers[0]);
-      expect(kpi.sellerId).toBe(sellers[0].id);
-      expect(kpi.sellerName).toBe(sellers[0].name);
-    });
-
-    it('emptyRow() returns placeholder row if seller is null', () => {
-      const kpi = util.emptyRow(null);
-      expect(kpi.sellerId).toBe('—');
-      expect(kpi.sellerName).toBe('—');
-    });
+  it('onSellerInputChange clears sellerId if not found', () => {
+    const ev = { target: { value: 'NoMatch' } } as unknown as Event;
+    component.onSellerInputChange(ev);
+    expect(component.filterForm.value.sellerId).toBe('');
+    expect(component.dropdownOpen).toBeTrue();
   });
 
-  describe('getBySeller() integration', () => {
-    let util: any;
+  it('closeOnClickOutside respects dropdown', () => {
+    const inside = document.createElement('div');
+    inside.classList.add('seller-dropdown');
+    component.dropdownOpen = true;
+    component.closeOnClickOutside({ target: inside } as unknown as MouseEvent);
+    expect(component.dropdownOpen).toBeTrue();
   
-    beforeEach(() => { util = component as any; });
-  
-    it('does NOT call emptyRow(sel) when KPI is returned for existing seller', fakeAsync(() => {
-      const target = sellers[0];
-  
-      const spy = spyOn(util, 'emptyRow').and.callThrough();
-  
-      component.selectSeller(target);
-      tick(250);
-  
-      expect(spy).not.toHaveBeenCalled();
-      expect(component.kpis()[0].sellerId).toBe(target.id);
-    }));
-  
-    it('sets KPI with ghost seller even if seller is not found in list', fakeAsync(() => {
-      const ghostSellerId = faker.string.uuid();
-      const ghostKpi = {
-        ...buildKpi({ id: ghostSellerId, name: 'Ghost' } as Seller),
-        sellerId: ghostSellerId,
-        sellerName: 'Ghost'
-      };
-    
-      kpiSvcSpy.getBySeller.and.returnValue(of(ghostKpi));
-    
-      const spy = spyOn(util, 'emptyRow').and.callThrough();
-    
-      component.selectSeller({ id: ghostSellerId, name: 'Ghost' } as Seller);
-      tick(250);
-    
-      expect(spy).not.toHaveBeenCalled();
-    
-      expect(component.kpis()[0].sellerId).toBe(ghostSellerId);
-      expect(component.kpis()[0].sellerName).toBe('Ghost');  // <- punto y coma correcto
-    }));
+    const outside = document.createElement('div');
+    component.closeOnClickOutside({ target: outside } as unknown as MouseEvent);
+    expect(component.dropdownOpen).toBeFalse();
   });
 
-  it('should return empty array if summaryKpi is null', () => {
+  it('closeOnEsc closes dropdown', () => {
+    component.dropdownOpen = true;
+    component.closeOnEsc();
+    expect(component.dropdownOpen).toBeFalse();
+  });
+
+
+  it('isSelectedSeller detects match', () => {
+    component.filterForm.patchValue({ sellerId: sellers[2].id });
+    expect(component.isSelectedSeller(sellers[2])).toBeTrue();
+    expect(component.isSelectedSeller(sellers[0])).toBeFalse();
+  });
+
+  it('emptyRow returns defaults if null', () => {
+    const result = (component as any).emptyRow(null);
+    expect(result.sellerId).toBe('—');
+    expect(result.sellerName).toBe('—');
+  });
+
+  it('emptyRow returns seller info if provided', () => {
+    const result = (component as any).emptyRow(sellers[0]);
+    expect(result.sellerId).toBe(sellers[0].id);
+  });
+
+  it('filterSellerNames matches names', () => {
+    const result = (component as any).filterSellerNames(
+      sellers[0].name.slice(1, 4).toUpperCase()
+    );
+    expect(result.some((s: Seller) => s.id === sellers[0].id)).toBeTrue();
+  });
+
+  it('cards returns empty array if summaryKpi is null', () => {
     spyOn(component, 'summaryKpi').and.returnValue(null);
-  
-    const result = component.cards;
-    expect(result).toEqual([]);
+    expect(component.cards).toEqual([]);
   });
 
-  it('should call loadKpis when refresh is invoked', () => {
-    const spy = spyOn(component as any, 'loadKpis'); 
-    component.refresh();
-    expect(spy).toHaveBeenCalled();
+  it('calcRange handles "month" and "quarter"', () => {
+    const resultMonth = (component as any).calcRange('month');
+    const resultQuarter = (component as any).calcRange('quarter');
+    expect(resultMonth[0]).toContain('T');
+    expect(resultQuarter[0]).toContain('T');
+  });
+
+  it('calcRange defaults to month on unknown input', () => {
+    const [start, end] = (component as any).calcRange('unexpected');
+    expect(start).toContain('T');
+    expect(end).toContain('T');
   });
 
 
-  it('should call emptyRow(sel) if kpi is falsy and set kpis with emptyRow', fakeAsync(() => {
-    const sellerId = faker.string.uuid();
-    const sellerName = faker.person.fullName();
+  describe('loadKpis() with sellerId', () => {
+    it('sets KPI and summaryKpi when KPI exists', fakeAsync(() => {
+      const seller = sellers[0];
+      component.filterForm.patchValue({ sellerId: seller.id, period: 'month' });
   
-    const seller: Seller = {
-      id: sellerId,
-      name: sellerName,
-      email: '',
-      phone: '',
-      address: '',
-      zone: '',
-      specialty: '',
-      password: ''
-    };
+      kpiSvcSpy.getBySeller.and.returnValue(of(kpis[0]));
   
-    spyOn(component, 'sellers').and.returnValue([seller]);
+      component['loadKpis']();
+      tick();
   
-    // Retorna null como KPI
-    kpiSvcSpy.getBySeller.and.returnValue(of(null));
+      expect(component.kpis()[0].sellerId).toBe(seller.id);
+      expect(component.summaryKpi()!.sellerId).toBe(seller.id);
+      expect(component.loadErr()).toBeFalse();
+    }));
   
-    // Simula una fila vacía generada
-    const emptyRowSpy = spyOn(component as any, 'emptyRow').and.callFake(() => ({
-      sellerId: '—',
-      sellerName: '—',
+    it('sets emptyRow when KPI is null', fakeAsync(() => {
+      const seller = sellers[1];
+      component.filterForm.patchValue({ sellerId: seller.id, period: 'month' });
+    
+      kpiSvcSpy.getBySeller.and.returnValue(of(null));
+    
+      const empty = {
+        sellerId: '—',
+        sellerName: '—',
+        clientCount: 0,
+        totalSales: 0,
+        monthlySales: 0,
+        quarterlySales: 0,
+        currency: 'USD'
+      };
+      const emptySpy = spyOn(component as any, 'emptyRow').and.returnValue(empty);
+    
+      component['loadKpis']();
+      tick();
+    
+      expect(emptySpy).toHaveBeenCalledWith(seller);
+      expect(component.kpis()[0]).toEqual(empty);
+      expect(component.summaryKpi()).toEqual(empty);
+    }));
+  
+    it('handles error response gracefully', fakeAsync(() => {
+      const seller = sellers[2];
+      component.filterForm.patchValue({ sellerId: seller.id, period: 'month' });
+  
+      kpiSvcSpy.getBySeller.and.returnValue(throwError(() => new Error('fail')));
+  
+      const loadErrSpy = spyOn(component['loadErr'], 'set').and.callThrough();
+      const kpisSpy = spyOn(component['kpis'], 'set').and.callThrough();
+      const summarySpy = spyOn(component['summaryKpi'], 'set').and.callThrough();
+  
+      component['loadKpis']();
+      tick();
+  
+      expect(loadErrSpy).toHaveBeenCalledWith(true);
+      expect(kpisSpy).toHaveBeenCalledWith([]);
+      expect(summarySpy).toHaveBeenCalledWith(null);
+    }));
+  });
+
+  describe('#getPerformanceLabel', () => {
+    it('returns GOOD when sales >= 10000', () => {
+      expect(component.getPerformanceLabel(12000)).toBe('PERFORMANCE_STATUS_GOOD');
+    });
+
+    it('returns AVERAGE when sales >= 5000 and < 10000', () => {
+      expect(component.getPerformanceLabel(6000)).toBe('PERFORMANCE_STATUS_AVERAGE');
+    });
+
+    it('returns LOW when sales < 5000', () => {
+      expect(component.getPerformanceLabel(3000)).toBe('PERFORMANCE_STATUS_LOW');
+    });
+  });
+
+  describe('#getPerformanceIcon', () => {
+    it('returns success icon when sales >= 10000', () => {
+      expect(component.getPerformanceIcon(15000)).toBe('bi bi-check-circle text-success');
+    });
+
+    it('returns warning icon when sales >= 5000 and < 10000', () => {
+      expect(component.getPerformanceIcon(6000)).toBe('bi bi-exclamation-circle text-warning');
+    });
+
+    it('returns danger icon when sales < 5000', () => {
+      expect(component.getPerformanceIcon(1000)).toBe('bi bi-x-circle text-danger');
+    });
+  });
+
+
+  it('sets seller as null if not found in seller list', fakeAsync(() => {
+    const ghostId = 'ghost-id';
+    const ghostKpi: PerformanceKpi = {
+      sellerId: ghostId,
+      sellerName: 'Ghost Seller',
       clientCount: 0,
       totalSales: 0,
       monthlySales: 0,
       quarterlySales: 0,
       currency: 'USD'
-    }));
-  
-    component.selectSeller(seller);
-    tick(250);
-  
-    expect(emptyRowSpy).toHaveBeenCalledWith(seller);
-  
-    const result = component.kpis()[0]; // ← accede por índice, asumiendo array
-    expect(result.sellerId).toBe('—');
-    expect(result.sellerName).toBe('—');
-  }));
-
-  describe('filterSellerNames input transformation', () => {
-    it('should handle null or undefined safely', () => {
-      const input1 = null;
-      const input2 = undefined;
-      const input3 = 'Carlos';
-  
-      const transform = (v: any) => (v ?? '').toString();
-  
-      expect(transform(input1)).toBe('');
-      expect(transform(input2)).toBe('');
-      expect(transform(input3)).toBe('Carlos');
-    });
-  });
-  
-
-  it('should set loadErr to true and clear kpis on error when selecting seller', fakeAsync(() => {
-    const sellerId = faker.string.uuid();
-    const sellerName = faker.person.fullName();
-  
-    const seller: Seller = {
-      id: sellerId,
-      name: sellerName,
-      email: '',
-      phone: '',
-      address: '',
-      zone: '',
-      specialty: '',
-      password: ''
     };
   
-    spyOn(component, 'sellers').and.returnValue([seller]);
+    kpiSvcSpy.getBySeller.and.returnValue(of(ghostKpi));
+    spyOn(component, 'sellers').and.returnValue([]);
   
-    kpiSvcSpy.getBySeller.and.returnValue(throwError(() => new Error('Test error')));
-  
-    const loadErrSpy = spyOn(component['loadErr'], 'set').and.callThrough();
-    const kpisSpy = spyOn(component['kpis'], 'set').and.callThrough();
-  
-    component.selectSeller(seller);
+    component.selectSeller({ id: ghostId, name: 'Ghost Seller' } as Seller);
     tick(250);
   
-    expect(loadErrSpy).toHaveBeenCalledWith(true);
-    expect(kpisSpy).toHaveBeenCalledWith([]);
+    expect(component.selectedSeller).toBeNull();
   }));
+
+
+  it('buildSummary() should fallback to acc.currency if cur.currency is undefined', () => {
+    const componentAny = component as any;
   
-
-
+    const kpiWithUndefinedCurrency: PerformanceKpi = {
+      sellerId: 's1',
+      sellerName: 'Vendedor A',
+      clientCount: 10,
+      totalSales: 1000,
+      monthlySales: 500,
+      quarterlySales: 800,
+      currency: undefined as any
+    };
   
+    const initialKpi: PerformanceKpi = {
+      sellerId: 's2',
+      sellerName: 'Vendedor B',
+      clientCount: 5,
+      totalSales: 500,
+      monthlySales: 300,
+      quarterlySales: 400,
+      currency: 'USD'
+    };
+  
+    const summary = componentAny.buildSummary([initialKpi, kpiWithUndefinedCurrency]);
+  
+    expect(summary.currency).toBe('USD');
+  });
 
+  it('asFormattedMoney() should default to USD and format with $ symbol', () => {
+    const result = component.asFormattedMoney(1234.56);
+    expect(result.amount).toBe('$1,234.56');
+    expect(result.currency).toBe('USD');
+  });
+
+  it('asFormattedMoney() should format amount with EUR symbol and uppercase code', () => {
+    const result = component.asFormattedMoney(789.1, 'eur');
+    expect(result.amount).toContain('€');
+    expect(result.currency).toBe('EUR');
+  });
+
+  it('asFormattedMoney() should extract $ symbol correctly for USD', () => {
+    const result = component.asFormattedMoney(1000, 'usd');
+    expect(result.amount.startsWith('$')).toBeTrue();
+    expect(result.amount).toBe('$1,000.00');
+  });
+
+  it('asFormattedMoney() should use $ when currency is USD and symbol is found', () => {
+    const result = component.asFormattedMoney(1234.56, 'usd');
+  
+    expect(result.amount).toBe('$1,234.56');
+    expect(result.currency).toBe('USD');
+  });
+
+  it('asFormattedMoney() should fallback to "$" when currency symbol is not found', () => {
+    const mockFormatter = {
+      formatToParts: () => [{ type: 'integer', value: '1234' }],
+      format: () => '1234.56'
+    };
+    spyOn(Intl, 'NumberFormat').and.returnValue(mockFormatter as any);
+  
+    const result = component.asFormattedMoney(1234.56, 'usd');
+  
+    expect(result.amount).toBe('$1234.56');
+    expect(result.currency).toBe('USD');
+  });
+
+  it('builds merged list with emptyRow when KPI is missing', () => {
+    const seller = buildSeller(); 
+    const kpiWithMatch = buildKpi(seller);
+    const otherSeller = buildSeller(); 
+  
+    const sellerList = [seller, otherSeller];
+    const kpiList = [kpiWithMatch];
+  
+    const emptyRowSpy = spyOn(component as any, 'emptyRow').and.callThrough();
+  
+    spyOn(component, 'sellers').and.returnValue(sellerList);
+    (component as any).kpis.set(kpiList);
+  
+    const mapKpi = new Map(kpiList.map(k => [k.sellerId, k]));
+    const merged = sellerList.map(s => mapKpi.get(s.id) ?? (component as any).emptyRow(s));
+  
+    expect(emptyRowSpy).toHaveBeenCalledWith(otherSeller);
+    expect(merged.length).toBe(2);
+    const fallbackKpi = merged.find(k => k.sellerId === otherSeller.id);
+    expect(fallbackKpi).toBeTruthy();
+    expect(fallbackKpi?.sellerName).toBe(otherSeller.name);
+    expect(emptyRowSpy).toHaveBeenCalledWith(otherSeller);
+  });
 });
-
-

--- a/src/app/performance/performance-dashboard/performance-dashboard.component.ts
+++ b/src/app/performance/performance-dashboard/performance-dashboard.component.ts
@@ -1,5 +1,3 @@
-//performance-dashboard.component.ts
-
 import {
   ChangeDetectionStrategy,
   Component,
@@ -9,104 +7,194 @@ import {
   signal
 } from '@angular/core';
 
-import { CommonModule }       from '@angular/common';
-import {
-  ReactiveFormsModule,
-  FormBuilder,
-  FormControl
-} from '@angular/forms';
-import { TranslateModule }    from '@ngx-translate/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, FormControl } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { Observable, of, combineLatest } from 'rxjs';
-import {
-  debounceTime,
-  finalize,
-  first,
-  map,
-  startWith
-} from 'rxjs/operators';
+import { debounceTime, finalize, first, map, startWith } from 'rxjs/operators';
 
 import { PerformanceReportService } from '../performance-report.service';
-import { SellerService }            from '../../seller/seller.service';
-import { Seller }                   from '../../seller/seller.model';
-import { PerformanceKpi }           from '../../models/performance-report.model';
+import { SellerService } from '../../seller/seller.service';
+import { AuthService } from '../../auth/auth.service';
+
+import { Seller } from '../../seller/seller.model';
+import { PerformanceKpi } from '../../models/performance-report.model';
+import { UserData } from '../../auth/auth.service';
 
 @Component({
-  standalone  : true,
-  selector    : 'app-performance-dashboard',
-  templateUrl : './performance-dashboard.component.html',
-  styleUrls   : ['./performance-dashboard.component.scss'],
-  imports     : [
-    CommonModule,
-    ReactiveFormsModule,
-    TranslateModule
-  ],
+  standalone: true,
+  selector: 'app-performance-dashboard',
+  templateUrl: './performance-dashboard.component.html',
+  styleUrls: ['./performance-dashboard.component.scss'],
+  imports: [CommonModule, ReactiveFormsModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PerformanceDashboardComponent implements OnInit {
+  sellers = signal<Seller[]>([]);
+  kpis = signal<PerformanceKpi[]>([]);
+  summaryKpi = signal<PerformanceKpi | null>(null);
+  loading = signal(false);
+  loadErr = signal(false);
+  sellersLoading = signal(false);
+  sellersErr = signal(false);
+  adminName = signal<string>('');
 
+  selectedSeller: Seller | null = null;
+  dropdownOpen = false;
   readonly skeletonRows = Array.from({ length: 6 });
   get isLoading() { return this.loading(); }
 
-  private fb        = inject(FormBuilder);
-  private kpiSvc    = inject(PerformanceReportService);
+  private fb = inject(FormBuilder);
+  private kpiSvc = inject(PerformanceReportService);
   private sellerSvc = inject(SellerService);
-
-  sellers        = signal<Seller[]>([]);
-  sellersLoading = signal(false);
-  sellersErr     = signal(false);
-
-  kpis       = signal<PerformanceKpi[]>([]);
-  summaryKpi = signal<PerformanceKpi | null>(null);
-  loading    = signal(false);
-  loadErr    = signal(false);
+  private auth = inject(AuthService);
 
   sellerNameControl = new FormControl<string>('');
-  filteredSellers$: Observable<Seller[]> = of([]);
-
   filterForm = this.fb.group({
     sellerId: [''],
-    period  : ['month']
+    period: ['month']
   });
-
-  dropdownOpen = false;
+  filteredSellers$: Observable<Seller[]> = of([]);
 
   ngOnInit(): void {
     this.fetchSellers();
     this.loadKpis();
+    this.loadAdminName();
+    this.watchFormChanges();
+    this.watchSellerAutocomplete();
+  }
 
+  private loadAdminName(): void {
+    const user: UserData | null = this.auth.getUser();
+    const name = user?.email?.split('@')[0] ?? '';
+    this.adminName.set(name);
+  }
+
+  private watchFormChanges(): void {
     this.filterForm.valueChanges
-        .pipe(debounceTime(200))
-        .subscribe(() => this.loadKpis());
+      .pipe(debounceTime(200))
+      .subscribe(() => this.loadKpis());
+  }
 
+  private watchSellerAutocomplete(): void {
     this.filteredSellers$ = this.sellerNameControl.valueChanges.pipe(
       startWith(''),
       debounceTime(200),
-      map(v => this.filterSellerNames((v ?? '').toString()))
+      map((value) => this.filterSellerNames(value ?? ''))
     );
   }
 
-  refresh(): void {
-    this.loadKpis();
+  private fetchSellers(): void {
+    this.sellersLoading.set(true);
+    this.sellersErr.set(false);
+
+    this.sellerSvc.getAll()
+      .pipe(first(), finalize(() => this.sellersLoading.set(false)))
+      .subscribe({
+        next: (list) => this.sellers.set(list),
+        error: () => this.sellersErr.set(true)
+      });
   }
 
-  clearFilters(): void {
-    this.filterForm.reset({ sellerId: '', period: 'month' });
-    this.sellerNameControl.reset('');
-    this.dropdownOpen = false;
+  private loadKpis(): void {
+    const { sellerId, period } = this.filterForm.value;
+    const [start, end] = this.calcRange(period ?? 'month');
+
+    this.loading.set(true);
+    this.loadErr.set(false);
+
+    if (sellerId) {
+      this.kpiSvc.getBySeller(sellerId, start, end)
+        .pipe(finalize(() => this.loading.set(false)))
+        .subscribe({
+          next: (kpi) => {
+            const seller = this.sellers().find(s => s.id === sellerId) ?? null;
+            const kpiList = kpi ? [kpi] : [this.emptyRow(seller)];
+            this.selectedSeller = seller;
+            this.kpis.set(kpiList);
+            this.summaryKpi.set(kpi ?? this.emptyRow(seller));
+          },
+          error: () => {
+            this.loadErr.set(true);
+            this.kpis.set([]);
+            this.summaryKpi.set(null);
+          }
+        });
+
+    } else {
+      this.selectedSeller = null;
+      combineLatest([
+        this.sellerSvc.getAll(),
+        this.kpiSvc.getAll(start, end)
+      ])
+        .pipe(finalize(() => this.loading.set(false)))
+        .subscribe({
+          next: ([sellers, kpis]) => {
+            const mapKpi = new Map(kpis.map(k => [k.sellerId, k]));
+            const merged = sellers.map(s => mapKpi.get(s.id) ?? this.emptyRow(s));
+            merged.sort((a, b) => b.totalSales - a.totalSales);
+            this.kpis.set(merged);
+            this.summaryKpi.set(this.buildSummary(merged));
+          },
+          error: () => {
+            this.loadErr.set(true);
+            this.kpis.set([]);
+            this.summaryKpi.set(null);
+          }
+        });
+    }
   }
 
-  onSellerInputChange(ev: Event): void {
-    const value = (ev.target as HTMLInputElement).value;
-    const sel = this.sellers().find(s => s.name === value);
-    this.filterForm.patchValue({ sellerId: sel?.id || '' });
-    this.dropdownOpen = true;
+  private buildSummary(kpis: PerformanceKpi[]): PerformanceKpi {
+    return kpis.reduce<PerformanceKpi>(
+      (acc, cur) => ({
+        sellerId: 'SUMMARY',
+        sellerName: 'Resumen',
+        clientCount: acc.clientCount + cur.clientCount,
+        totalSales: acc.totalSales + cur.totalSales,
+        monthlySales: acc.monthlySales + cur.monthlySales,
+        quarterlySales: acc.quarterlySales + cur.quarterlySales,
+        currency: cur.currency || acc.currency
+      }),
+      {
+        sellerId: 'SUMMARY',
+        sellerName: 'Resumen',
+        clientCount: 0,
+        totalSales: 0,
+        monthlySales: 0,
+        quarterlySales: 0,
+        currency: 'usd'
+      }
+    );
   }
 
-  selectSeller(sel: Seller): void {
-    this.sellerNameControl.setValue(sel.name, { emitEvent: true });
-    this.filterForm.patchValue({ sellerId: sel.id });
-    this.dropdownOpen = false;
+  private emptyRow(s: Seller | null): PerformanceKpi {
+    return {
+      sellerId: s?.id ?? '—',
+      sellerName: s?.name ?? '—',
+      clientCount: 0,
+      totalSales: 0,
+      monthlySales: 0,
+      quarterlySales: 0,
+      currency: 'usd'
+    };
+  }
+
+  private calcRange(period: string): [string, string] {
+    const now = new Date();
+    if (period === 'quarter') {
+      const start = new Date(now.getFullYear(), now.getMonth() - 2, 1);
+      return [start.toISOString(), now.toISOString()];
+    }
+    const start = new Date(now.getFullYear(), now.getMonth(), 1);
+    return [start.toISOString(), now.toISOString()];
+  }
+
+  private filterSellerNames(value: string): Seller[] {
+    return this.sellers().filter(s =>
+      s.name.toLowerCase().includes(value.toLowerCase())
+    );
   }
 
   @HostListener('document:click', ['$event'])
@@ -118,111 +206,72 @@ export class PerformanceDashboardComponent implements OnInit {
   }
 
   @HostListener('keydown.escape')
-  closeOnEsc() { this.dropdownOpen = false; }
-
-  private fetchSellers(): void {
-    this.sellersLoading.set(true);
-    this.sellersErr.set(false);
-
-    this.sellerSvc.getAll()
-      .pipe(first(), finalize(() => this.sellersLoading.set(false)))
-      .subscribe({
-        next : list => this.sellers.set(list),
-        error: ()   => this.sellersErr.set(true)
-      });
+  closeOnEsc() {
+    this.dropdownOpen = false;
   }
 
-  private loadKpis(): void {
-    const { sellerId, period } = this.filterForm.value;
-    const [start, end]         = this.calcRange(period!);
+  onSellerInputChange(ev: Event): void {
+    const value = (ev.target as HTMLInputElement).value;
+    const sel = this.sellers().find(s => s.name === value);
+    this.filterForm.patchValue({ sellerId: sel?.id || '' });
+    this.selectedSeller = sel ?? null;
+    this.dropdownOpen = true;
+  }
 
-    this.loading.set(true);
-    this.loadErr.set(false);
-
-    if (sellerId) {
-      this.kpiSvc.getBySeller(sellerId, start, end)
-        .pipe(finalize(() => this.loading.set(false)))
-        .subscribe({
-          next : kpi => {
-            const sel = this.sellers().find(s => s.id === sellerId) ?? null;
-            this.kpis.set(kpi ? [kpi] : [this.emptyRow(sel)]);
-          },
-          error: () => { this.loadErr.set(true); this.kpis.set([]); }
-        });
-
-      this.kpiSvc.getSummary(start, end)
-                 .subscribe(sum => this.summaryKpi.set(sum));
-      return;
-    }
-
-    combineLatest([
-      this.sellerSvc.getAll(),
-      this.kpiSvc.getAll(start, end)
-    ])
-    .pipe(finalize(() => this.loading.set(false)))
-    .subscribe({
-      next : ([sellers, kpis]) => {
-        const mapK = new Map(kpis.map(k => [k.sellerId, k]));
-        this.kpis.set(
-          sellers.map(s => mapK.get(s.id) ?? this.emptyRow(s))
-        );
-      },
-      error: () => { this.loadErr.set(true); this.kpis.set([]); }
-    });
-
-    this.kpiSvc.getSummary(start, end)
-               .subscribe(sum => this.summaryKpi.set(sum));
+  selectSeller(sel: Seller): void {
+    this.sellerNameControl.setValue(sel.name, { emitEvent: true });
+    this.filterForm.patchValue({ sellerId: sel.id });
+    this.selectedSeller = sel;
+    this.dropdownOpen = false;
   }
 
   get cards() {
     const s = this.summaryKpi();
-    if (!s) { return []; }
+    if (!s) return [];
     return [
-      { title: 'CARD_CLIENTS',       value: s.clientCount },
-      { title: 'CARD_TOTAL_SALES',   value: this.asMoney(s.totalSales,   s.currency) },
-      { title: 'CARD_MONTH_SALES',   value: this.asMoney(s.monthlySales, s.currency) },
-      { title: 'CARD_QUARTER_SALES', value: this.asMoney(s.quarterlySales, s.currency) }
+      { title: 'CARD_CLIENTS', value: { amount: s.clientCount.toString(), currency: '' } },
+      { title: 'CARD_TOTAL_SALES', value: this.asFormattedMoney(s.totalSales, s.currency) },
+      { title: 'CARD_MONTH_SALES', value: this.asFormattedMoney(s.monthlySales, s.currency) },
+      { title: 'CARD_QUARTER_SALES', value: this.asFormattedMoney(s.quarterlySales, s.currency) }
     ];
   }
 
-  private asMoney(amount: number, cur = 'usd') {
-    return new Intl.NumberFormat(undefined,
-      { style: 'currency', currency: cur }).format(amount);
-  }
+  public asFormattedMoney(amount: number, cur = 'usd') {
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: cur.toUpperCase(),
+      currencyDisplay: 'symbol',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
+    });
 
-  private emptyRow(s: Seller | null): PerformanceKpi {
+    const symbol = formatter.formatToParts(0).find(p => p.type === 'currency')?.value ?? '$';
+    const formatted = formatter.format(amount);
+
     return {
-      sellerId       : s?.id   ?? '—',
-      sellerName     : s?.name ?? '—',
-      clientCount    : 0,
-      totalSales     : 0,
-      monthlySales   : 0,
-      quarterlySales : 0,
-      currency       : 'usd'
+      amount: `${symbol}${formatted.replace(symbol, '').trim()}`,
+      currency: cur.toUpperCase()
     };
   }
 
-  private calcRange(period: string): [string, string] {
-    const now = new Date();
-    if (period === 'quarter') {
-      const start = new Date(now.getFullYear(), now.getMonth() - 2, 1);
-      return [start.toISOString(), now.toISOString()];
-    }
-    if (period === 'month') {
-      const start = new Date(now.getFullYear(), now.getMonth(), 1);
-      return [start.toISOString(), now.toISOString()];
-    }
-    return ['', ''];
-  }
-
-  private filterSellerNames(v: string): Seller[] {
-    return this.sellers()
-               .filter(s => s.name.toLowerCase().includes(v.toLowerCase()));
-  }
-  
   isSelectedSeller(s: Seller): boolean {
     return this.filterForm.value.sellerId === s.id;
   }
 
-  trackById(_: number, k: PerformanceKpi) { return k.sellerId; }
+  trackById(_: number, k: PerformanceKpi) {
+    return k.sellerId;
+  }
+
+
+  getPerformanceLabel(sales: number): string {
+    if (sales >= 10000) return 'PERFORMANCE_STATUS_GOOD';
+    if (sales >= 5000) return 'PERFORMANCE_STATUS_AVERAGE';
+    return 'PERFORMANCE_STATUS_LOW';
+  }
+  
+  getPerformanceIcon(sales: number): string {
+    if (sales >= 10000) return 'bi bi-check-circle text-success'; 
+    if (sales >= 5000) return 'bi bi-exclamation-circle text-warning';
+    return 'bi bi-x-circle text-danger'; 
+  }
 }


### PR DESCRIPTION
This pull request introduces significant updates to the performance dashboard, including enhancements to the user interface, improved internationalization support, and modifications to the test suite. Below is a breakdown of the most important changes:

### User Interface Enhancements:
* Redesigned the performance dashboard layout to improve usability and accessibility, including updated card styles, table headers, and spinner positioning. Added performance icons and labels for KPIs in the table to provide visual feedback on performance levels (`src/app/performance/performance-dashboard/performance-dashboard.component.html`, [[1]](diffhunk://#diff-035f36b65e5ed69eb8d66a62325127f66dfcecb8ec5ef4ae3340f42683f8c9fcL1-L107) [[2]](diffhunk://#diff-035f36b65e5ed69eb8d66a62325127f66dfcecb8ec5ef4ae3340f42683f8c9fcL120-R165).

### Internationalization Updates:
* Added new translations for performance-related terms in both English (`public/assets/i18n/en.json`, [[1]](diffhunk://#diff-9a0f75ed2ef501cd2a1f45d6cb6996f54226c546d93cae9b8ade9d860f307765L484-R501) and Spanish (`public/assets/i18n/es.json`, [[2]](diffhunk://#diff-0417bfdfaa96e3f3182ca3cf34ee290262fa3c9b860567d28a0701af72e29492L484-R501) including labels for KPIs, performance statuses, and global results.

### Test Suite Improvements:
* Refactored the `PerformanceDashboardComponent` test suite by simplifying test setup, removing unused test cases (e.g., reactive seller name filtering and clear filters), and adding `HttpClientTestingModule` for better dependency isolation (`src/app/performance/performance-dashboard/performance-dashboard.component.spec.ts`, [[1]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L1-R12) [[2]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L37-R53) [[3]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L70-R69) [[4]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289R85-R90) [[5]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L112-L136).
This pull request introduces significant updates to the performance dashboard, including enhancements to the user interface, improved internationalization support, and modifications to the test suite. Below is a breakdown of the most important changes:

### User Interface Enhancements:
* Redesigned the performance dashboard layout to improve usability and accessibility, including updated card styles, table headers, and spinner positioning. Added performance icons and labels for KPIs in the table to provide visual feedback on performance levels (`src/app/performance/performance-dashboard/performance-dashboard.component.html`, [[1]](diffhunk://#diff-035f36b65e5ed69eb8d66a62325127f66dfcecb8ec5ef4ae3340f42683f8c9fcL1-L107) [[2]](diffhunk://#diff-035f36b65e5ed69eb8d66a62325127f66dfcecb8ec5ef4ae3340f42683f8c9fcL120-R165).

### Internationalization Updates:
* Added new translations for performance-related terms in both English (`public/assets/i18n/en.json`, [[1]](diffhunk://#diff-9a0f75ed2ef501cd2a1f45d6cb6996f54226c546d93cae9b8ade9d860f307765L484-R501) and Spanish (`public/assets/i18n/es.json`, [[2]](diffhunk://#diff-0417bfdfaa96e3f3182ca3cf34ee290262fa3c9b860567d28a0701af72e29492L484-R501) including labels for KPIs, performance statuses, and global results.

### Test Suite Improvements:
* Refactored the `PerformanceDashboardComponent` test suite by simplifying test setup, removing unused test cases (e.g., reactive seller name filtering and clear filters), and adding `HttpClientTestingModule` for better dependency isolation (`src/app/performance/performance-dashboard/performance-dashboard.component.spec.ts`, [[1]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L1-R12) [[2]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L37-R53) [[3]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L70-R69) [[4]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289R85-R90) [[5]](diffhunk://#diff-99154dedf516fecc14e3006b5c26cd260ab46151898b879a9243bed8ce33e289L112-L136).